### PR TITLE
Revert "newer version of the dependency imagemagick flipped images after conversion"

### DIFF
--- a/game/platforms/SDL/Makefile.all
+++ b/game/platforms/SDL/Makefile.all
@@ -135,10 +135,10 @@ include ${LAYER_DEPENDS}
 # $<   represents the name.png file
 #
 graphics/%.tga: %.png
-	convert -auto-orient $< -type truecolormatte $@
+	convert $< -type truecolormatte $@
 graphics/%.tga: graphicsSource/%.png
-	convert -auto-orient $< -type truecolormatte $@
+	convert $< -type truecolormatte $@
 music/%.tga: %.png
-	convert -auto-orient $< -type truecolormatte $@
+	convert $< -type truecolormatte $@
 
 


### PR DESCRIPTION
This reverts commit de9049d978784c1b91cf9d03e335c0b5991ea42c.

Seems the old version of imagemagick is much more common, fixing this in this repo causes more problems than it solves. This is fixed in miniOneLifeCompile scripts instead.