### PR TITLE
Add unmodified keyboard callback

### DIFF
--- a/game/game.h
+++ b/game/game.h
@@ -183,6 +183,9 @@ void specialKeyDown( int inKeyCode );
 void specialKeyUp( int inKeyCode );
 
 
+void unmodifiedKeyDown( unsigned char inASCII );
+
+void unmodifiedKeyUp( unsigned char inASCII );
 
 
 

--- a/game/platforms/SDL/gameSDL.cpp
+++ b/game/platforms/SDL/gameSDL.cpp
@@ -441,6 +441,8 @@ class GameSceneHandler :
 		virtual void specialKeyPressed( int inKey, int inX, int inY );
 		virtual void keyReleased( unsigned char inKey, int inX, int inY );
 		virtual void specialKeyReleased( int inKey, int inX, int inY );
+        virtual void unmodifiedKeyPressed( unsigned char inKey );
+        virtual void unmodifiedKeyReleased( unsigned char inKey );
         
         // implements the RedrawListener interface
 		virtual void fireRedraw();
@@ -4029,6 +4031,19 @@ void GameSceneHandler::specialKeyReleased(
 
     specialKeyUp( inKey );
     } 
+
+
+void GameSceneHandler::unmodifiedKeyPressed(
+	unsigned char inKey ) {
+
+    unmodifiedKeyDown( inKey );
+    }
+
+void GameSceneHandler::unmodifiedKeyReleased(
+	unsigned char inKey ) {
+
+    unmodifiedKeyUp( inKey );
+    }
 
 
 

--- a/graphics/openGL/KeyboardHandlerGL.h
+++ b/graphics/openGL/KeyboardHandlerGL.h
@@ -33,40 +33,39 @@
 
 
 // special key codes
-#define  MG_KEY_F1                        0x0001
-#define  MG_KEY_F2                        0x0002
-#define  MG_KEY_F3                        0x0003
-#define  MG_KEY_F4                        0x0004
-#define  MG_KEY_F5                        0x0005
-#define  MG_KEY_F6                        0x0006
-#define  MG_KEY_F7                        0x0007
-#define  MG_KEY_F8                        0x0008
-#define  MG_KEY_F9                        0x0009
-#define  MG_KEY_F10                       0x000A
-#define  MG_KEY_F11                       0x000B
-#define  MG_KEY_F12                       0x000C
-#define  MG_KEY_LEFT                      0x0064
-#define  MG_KEY_UP                        0x0065
-#define  MG_KEY_RIGHT                     0x0066
-#define  MG_KEY_DOWN                      0x0067
-#define  MG_KEY_PAGE_UP                   0x0068
-#define  MG_KEY_PAGE_DOWN                 0x0069
-#define  MG_KEY_HOME                      0x006A
-#define  MG_KEY_END                       0x006B
-#define  MG_KEY_INSERT                    0x006C
-
-#define  MG_KEY_RSHIFT                    0x0070
-#define  MG_KEY_LSHIFT                    0x0071
-#define  MG_KEY_RCTRL                     0x0072
-#define  MG_KEY_LCTRL                     0x0073
-#define  MG_KEY_RALT                      0x0074
-#define  MG_KEY_LALT                      0x0075
-#define  MG_KEY_RMETA                     0x0076
-#define  MG_KEY_LMETA                     0x0077
+#define  MG_KEY_F1           128
+#define  MG_KEY_F2           129
+#define  MG_KEY_F3           130
+#define  MG_KEY_F4           131
+#define  MG_KEY_F5           132
+#define  MG_KEY_F6           133
+#define  MG_KEY_F7           134
+#define  MG_KEY_F8           135
+#define  MG_KEY_F9           136
+#define  MG_KEY_F10          137
+#define  MG_KEY_F11          138
+#define  MG_KEY_F12          139
+#define  MG_KEY_LEFT         140
+#define  MG_KEY_UP           141
+#define  MG_KEY_RIGHT        142
+#define  MG_KEY_DOWN         143
+#define  MG_KEY_PAGE_UP      144
+#define  MG_KEY_PAGE_DOWN    145
+#define  MG_KEY_HOME         146
+#define  MG_KEY_END          147
+#define  MG_KEY_INSERT       148
+#define  MG_KEY_RSHIFT       149
+#define  MG_KEY_LSHIFT       150
+#define  MG_KEY_RCTRL        151
+#define  MG_KEY_LCTRL        152
+#define  MG_KEY_RALT         153
+#define  MG_KEY_LALT         154
+#define  MG_KEY_RMETA        155
+#define  MG_KEY_LMETA        156
 
 
 // bounds of key constants
-#define  MG_KEY_FIRST_CODE    MG_KEY_F1                     
+#define  MG_KEY_FIRST_CODE    MG_KEY_F1
 #define  MG_KEY_LAST_CODE     MG_KEY_LMETA                     
 
 
@@ -145,6 +144,9 @@ class KeyboardHandlerGL {
 		 */
 		virtual void specialKeyReleased( int inKey, int inX, int inY ) = 0;
 
+
+		virtual void unmodifiedKeyPressed( unsigned char inKey ) { }
+		virtual void unmodifiedKeyReleased( unsigned char inKey ) { }
 
         char mHandlerFlagged;
 

--- a/graphics/openGL/ScreenGL.h
+++ b/graphics/openGL/ScreenGL.h
@@ -707,6 +707,8 @@ class ScreenGL {
 		friend void callbackPreDisplay();
         friend void callbackDisplay();
 		friend void callbackIdle();
+		friend void callbackUnmodifiedKeyboard( unsigned char inKey );
+		friend void callbackUnmodifiedKeyboardUp( unsigned char inKey );
 		
 
 

--- a/graphics/openGL/ScreenGL_SDL.cpp
+++ b/graphics/openGL/ScreenGL_SDL.cpp
@@ -1946,7 +1946,7 @@ void ScreenGL::start() {
 
                         int n = ToUnicodeEx(vk, scancode, state, out, 4, 0, hkl);
 
-                        if ( n == 1 && out[0] <= 255 ) asciiKeyUnmodified = (unsigned char)out[0];
+                        if( n == 1 && ( out[0] >= 32 && out[0] < 127 ) ) asciiKeyUnmodified = (unsigned char)out[0];
 
                         #else
                         SDLKey sym = event.key.keysym.sym;

--- a/graphics/openGL/ScreenGL_SDL.cpp
+++ b/graphics/openGL/ScreenGL_SDL.cpp
@@ -217,6 +217,9 @@ void callbackDisplay();
 void callbackIdle();
 */
 
+void callbackUnmodifiedKeyboard( unsigned char inKey );
+void callbackUnmodifiedKeyboardUp( unsigned char inKey );
+
 ScreenGL::ScreenGL( int inWide, int inHigh, char inFullScreen,
                     char inDoNotChangeNativeResolution,
                     unsigned int inMaxFrameRate,
@@ -1927,6 +1930,17 @@ void ScreenGL::start() {
                                 asciiKey = scanCodeMap[event.key.keysym.scancode];
                             }
 
+                        unsigned char asciiKeyUnmodified = 0;
+                        SDLKey sym = event.key.keysym.sym;
+                        if( sym >= 32 && sym < 127 ) asciiKeyUnmodified = (unsigned char)sym;
+
+                        if( event.type == SDL_KEYDOWN ) {
+                            callbackUnmodifiedKeyboard( asciiKeyUnmodified );
+                            }
+                        else {
+                            callbackUnmodifiedKeyboardUp( asciiKeyUnmodified );
+                            }
+
                         if( asciiKey != 0 ) {
                             if( event.type == SDL_KEYDOWN ) {
                                 callbackKeyboard( asciiKey, mouseX, mouseY );
@@ -2614,8 +2628,8 @@ void callbackKeyboardUp( unsigned char inKey, int inX, int inY ) {
     
 	}	
 
-	
-	
+
+
 void callbackSpecialKeyboard( int inKey, int inX, int inY ) {
     if( currentScreenGL->mRecordingEvents &&
         currentScreenGL->mRecordingOrPlaybackStarted ) {
@@ -2726,6 +2740,73 @@ void callbackSpecialKeyboardUp( int inKey, int inX, int inY ) {
     
 	}	
 
+void callbackUnmodifiedKeyboard( unsigned char inKey ) {
+    char someFocused = currentScreenGL->isKeyboardHandlerFocused();
+
+    int h;
+    for( h=0; h<currentScreenGL->mKeyboardHandlerVector->size(); h++ ) {
+        KeyboardHandlerGL *handler
+			= *( currentScreenGL->mKeyboardHandlerVector->getElement( h ) );
+        handler->mHandlerFlagged = true;
+        }
+
+        for( h=0; h<currentScreenGL->mKeyboardHandlerVector->size(); h++ ) {
+		KeyboardHandlerGL *handler
+			= *( currentScreenGL->mKeyboardHandlerVector->getElement( h ) );
+
+        if( handler->mHandlerFlagged ) {
+            if( !someFocused || handler->isFocused() ) {
+                handler->unmodifiedKeyPressed( inKey );
+                if( handler->mEatEvent ) {
+                    handler->mEatEvent = false;
+                    goto unmodified_down_eaten;
+                    }
+                }
+            }
+        }
+
+    unmodified_down_eaten:
+
+    for( h=0; h<currentScreenGL->mKeyboardHandlerVector->size(); h++ ) {
+        KeyboardHandlerGL *handler
+			= *( currentScreenGL->mKeyboardHandlerVector->getElement( h ) );
+        handler->mHandlerFlagged = false;
+        }
+    }
+void callbackUnmodifiedKeyboardUp( unsigned char inKey ) {
+    char someFocused = currentScreenGL->isKeyboardHandlerFocused();
+
+    int h;
+    for( h=0; h<currentScreenGL->mKeyboardHandlerVector->size(); h++ ) {
+        KeyboardHandlerGL *handler
+			= *( currentScreenGL->mKeyboardHandlerVector->getElement( h ) );
+        handler->mHandlerFlagged = true;
+        }
+
+        for( h=0; h<currentScreenGL->mKeyboardHandlerVector->size(); h++ ) {
+		KeyboardHandlerGL *handler
+			= *( currentScreenGL->mKeyboardHandlerVector->getElement( h ) );
+
+        if( handler->mHandlerFlagged ) {
+            if( !someFocused || handler->isFocused() ) {
+                handler->unmodifiedKeyReleased( inKey );
+                if( handler->mEatEvent ) {
+                    handler->mEatEvent = false;
+                    goto unmodified_up_eaten;
+                    }
+                }
+            }
+        }
+
+    unmodified_up_eaten:
+    
+    for( h=0; h<currentScreenGL->mKeyboardHandlerVector->size(); h++ ) {
+        KeyboardHandlerGL *handler 
+			= *( currentScreenGL->mKeyboardHandlerVector->getElement( h ) );
+        handler->mHandlerFlagged = false;
+        }
+    }
+	
 
 	
 void callbackMotion( int inX, int inY ) {

--- a/graphics/openGL/ScreenGL_SDL.cpp
+++ b/graphics/openGL/ScreenGL_SDL.cpp
@@ -162,6 +162,10 @@
 #include "minorGems/crypto/hashes/sha1.h"
 #include "minorGems/formats/encodingUtils.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #ifdef __mac__
 #include "minorGems/game/platforms/SDL/mac/SDLMain_Ext.h"
 #endif
@@ -1929,11 +1933,27 @@ void ScreenGL::start() {
                         else {
                                 asciiKey = scanCodeMap[event.key.keysym.scancode];
                             }
-
+                        
                         unsigned char asciiKeyUnmodified = 0;
+                        
+                        #ifdef _WIN32
+                        Uint8 scancode = event.key.keysym.scancode;
+                        HKL hkl = GetKeyboardLayout(0);
+                        UINT vk = MapVirtualKeyExW(scancode, MAPVK_VSC_TO_VK, hkl);
+
+                        unsigned char state[256] = {0};
+                        wchar_t out[4] = {0};
+
+                        int n = ToUnicodeEx(vk, scancode, state, out, 4, 0, hkl);
+
+                        if ( n == 1 && out[0] <= 255 ) asciiKeyUnmodified = (unsigned char)out[0];
+
+                        #else
                         SDLKey sym = event.key.keysym.sym;
                         if( sym >= 32 && sym < 127 ) asciiKeyUnmodified = (unsigned char)sym;
 
+                        #endif
+                        
                         if( event.type == SDL_KEYDOWN ) {
                             callbackUnmodifiedKeyboard( asciiKeyUnmodified );
                             }

--- a/graphics/openGL/ScreenGL_SDL.cpp
+++ b/graphics/openGL/ScreenGL_SDL.cpp
@@ -1946,19 +1946,21 @@ void ScreenGL::start() {
 
                         int n = ToUnicodeEx(vk, scancode, state, out, 4, 0, hkl);
 
-                        if( n == 1 && ( out[0] >= 32 && out[0] < 127 ) ) asciiKeyUnmodified = (unsigned char)out[0];
+                        if( n == 1 ) asciiKeyUnmodified = (unsigned char)out[0];
 
                         #else
                         SDLKey sym = event.key.keysym.sym;
-                        if( sym >= 32 && sym < 127 ) asciiKeyUnmodified = (unsigned char)sym;
+                        asciiKeyUnmodified = (unsigned char)sym;
 
                         #endif
                         
-                        if( event.type == SDL_KEYDOWN ) {
-                            callbackUnmodifiedKeyboard( asciiKeyUnmodified );
-                            }
-                        else {
-                            callbackUnmodifiedKeyboardUp( asciiKeyUnmodified );
+                        if( asciiKeyUnmodified != 0 && asciiKeyUnmodified < 128 ) {
+                            if( event.type == SDL_KEYDOWN ) {
+                                callbackUnmodifiedKeyboard( asciiKeyUnmodified );
+                                }
+                            else {
+                                callbackUnmodifiedKeyboardUp( asciiKeyUnmodified );
+                                }
                             }
 
                         if( asciiKey != 0 ) {


### PR DESCRIPTION
Adds a function to pass unmodified ASCII to the game handler. Currently, the only text that's passed is the Unicode character after modifiers like Shift/Ctrl are applied. For any combination that produces ASCII 0, recovering the base key isn't possible, as far as I know. While this behavior is fine for typed text, it prevents any keybinds that don't go through.

Getting the base key on SDL 1.2 differs by OS. On Linux, event.key.keysym.sym is accurate to the active keyboard layout. However, on Windows, SDL 1.2 assumes a QWERTY layout for sym. The base key is instead translated from the scancode using ToUnicodeEx from the win32 api. 

I also changed the MG_KEY constants to start sequentially at 128. I believe Jason originally assigned the values based on their GLUT codes.

Needed by: https://github.com/twohoursonelife/OneLife/pull/305/commits/840050a90e655774610e02eba509fdfcc07632e2